### PR TITLE
add types except Codec and QueryResult

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,16 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import { web3FromSource } from "@polkadot/extension-dapp";
-import { useContext, useEffect, useState } from "react";
-import { ConnectWallet } from "./components/ConnectWallet";
+import { useEffect, useState } from "react";
 import AccountSelector from "./components/AccountSelector";
+import { ConnectWallet } from "./components/ConnectWallet";
 import "./index.css";
-import { AccountContext } from "./hooks/useAccount";
 import toast, { Toaster } from "react-hot-toast";
-import { formatBalance } from "./utils/helper";
+import useAccount from "./hooks/useAccount";
 import { DECIMAL } from "./utils/constants";
+import { formatBalance } from "./utils/helper";
 
 function App() {
-  const { selectedAccount } = useContext(AccountContext);
+  const { selectedAccount } = useAccount()
 
   const [recipientAddress, setRecipientAddress] = useState("");
   const [amount, setAmount] = useState("");
@@ -19,15 +19,16 @@ function App() {
   const [seletedTokenBalance, setSelectedTokenBalance] = useState();
   const [transacting, setTransacting] = useState(false);
 
-  const handleRecipientChange = (event) => {
+  const handleRecipientChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRecipientAddress(event.target.value);
   };
 
-  const handleAmountChange = (event) => {
+  const handleAmountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setAmount(event.target.value);
   };
 
   const handleTransact = async () => {
+    if (!selectedAccount) return;
     setTransacting(true);
     if (!api) {
       toast.error("Cannot connect to the blockchain!");
@@ -80,7 +81,7 @@ function App() {
             }
           }
         )
-        .catch((error: any) => {
+        .catch((error: Error) => {
           toast.error(`:( transaction failed ${error}`);
           setTransacting(false);
         });
@@ -90,7 +91,7 @@ function App() {
     }
   };
 
-  async function getTokenBalance(address, assetId) {
+  async function getTokenBalance(address: string, assetId: string) {
     const query_result: Codec | null = await api?.query.assets.account(
       assetId,
       address
@@ -210,11 +211,10 @@ function App() {
               </div>
             </div>
             <button
-              className={`w-full border border-black p-4 rounded-lg font-bold ${
-                transacting
-                  ? "bg-gray-200"
-                  : "hover:bg-gray-200 active:bg-gray-200"
-              }`}
+              className={`w-full border border-black p-4 rounded-lg font-bold ${transacting
+                ? "bg-gray-200"
+                : "hover:bg-gray-200 active:bg-gray-200"
+                }`}
               onClick={handleTransact}
               disabled={transacting}
             >

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -1,7 +1,7 @@
-import { useContext, useState } from "react";
-import { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { Keyring } from "@polkadot/api";
-import { AccountContext } from "../hooks/useAccount";
+import { useState } from "react";
+import useAccount from "../hooks/useAccount";
+import { Account } from "../contexts/account";
 
 // type Props = {
 //   setAccounts: (accounts: InjectedAccountWithMeta[]) => void;
@@ -9,20 +9,20 @@ import { AccountContext } from "../hooks/useAccount";
 // };
 
 const POLKADOT_ASSET_HUB = 0;
-function formatAddress(array, encode) {
+function formatAddress(accounts: Account[], encode: number) {
   const keyring = new Keyring();
 
   if (encode === POLKADOT_ASSET_HUB)
-    return array.map((obj) => ({
+    return accounts.map((obj) => ({
       ...obj,
       address: keyring.encodeAddress(obj.address, encode),
     }));
 
-  return array;
+  return accounts;
 }
 
-export const ConnectWallet: React.FC<Props> = () => {
-  const { selectAccount, updateAccounts } = useContext(AccountContext);
+export const ConnectWallet: React.FC = () => {
+  const { selectAccount, updateAccounts } = useAccount();
 
   const [connecting, setConnecting] = useState(false);
 

--- a/src/contexts/account.ts
+++ b/src/contexts/account.ts
@@ -1,0 +1,30 @@
+import { createContext } from "react";
+
+export type KeypairType = 'ed25519' | 'sr25519' | 'ecdsa' | 'ethereum';
+export type Account = {
+    address: string;
+    meta: {
+        genesisHash?: string | null;
+        name?: string;
+        source: string;
+    };
+    type?: KeypairType;
+}
+export type AccountContextType = {
+
+
+    accounts: Account[],
+    selectedAccount: Account | undefined,
+    updateAccounts: (accounts: Account[]) => void,
+    selectAccount: (account: Account | undefined) => void,
+
+
+}
+export const AccountContext = createContext<AccountContextType>({
+
+    accounts: [],
+    selectedAccount: undefined,
+    updateAccounts: () => { },
+    selectAccount: () => { },
+
+});

--- a/src/hooks/useAccount.tsx
+++ b/src/hooks/useAccount.tsx
@@ -1,30 +1,13 @@
-import React, { createContext, useState, useContext } from "react";
+import { useContext } from 'react'
+import { AccountContext } from '../contexts/account'
 
-// Create a context
-const AccountContext = createContext();
 
-// Provider component
-function AccountProvider({ children }) {
-  const [accounts, setAccounts] = useState([]);
-  const [selectedAccount, setSelectedAccount] = useState(null);
-
-  // Function to update accounts
-  const updateAccounts = (newAccounts) => {
-    setAccounts(newAccounts);
-  };
-
-  // Function to select an account
-  const selectAccount = (account) => {
-    setSelectedAccount(account);
-  };
-
-  return (
-    <AccountContext.Provider
-      value={{ accounts, selectedAccount, updateAccounts, selectAccount }}
-    >
-      {children}
-    </AccountContext.Provider>
-  );
+const useAccount = () => {
+  const context = useContext(AccountContext)
+  if (context === undefined) {
+    throw new Error('useAccount must be used within an AccountProvider')
+  }
+  return context
 }
 
-export { AccountProvider, AccountContext };
+export default useAccount

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
-import { AccountProvider } from "./hooks/useAccount.tsx";
+import AccountProvider from "./providers/AccountProvider.tsx";
+// import { AccountProvider } from "./hooks/useAccount.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { Account, AccountContext } from "../contexts/account";
+type Props = {
+    children?: React.ReactNode
+}
+function AccountProvider({ children }: Props) {
+    const [accounts, setAccounts] = useState<Account[]>([]);
+    const [selectedAccount, setSelectedAccount] = useState<Account>();
+
+    // Function to update accounts
+    const updateAccounts = (newAccounts: Account[]) => {
+        setAccounts(newAccounts);
+    };
+
+    // Function to select an account
+    const selectAccount = (account: Account | undefined) => {
+        setSelectedAccount(account);
+    };
+
+    return (
+        <AccountContext.Provider
+            value={{ accounts, selectedAccount, updateAccounts, selectAccount }}
+        >
+            {children}
+        </AccountContext.Provider>
+    );
+}
+
+export default AccountProvider;


### PR DESCRIPTION
1. I rewrote the `useAccount` hook by diving parts to `contexts`, `providers`.
2. Add type for most of the function, except the `polkadot.js` type -> Codec and QueryResult.

